### PR TITLE
Add an error log line after the GET on editions for a code list

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -61,6 +61,10 @@ func HomepageRender(rend RenderClient, cli *codelist.Client) http.HandlerFunc {
 				typesID := v.Links.Self.ID
 				editionsListResults, err := cli.GetEditionslistData(v.Links.Editions.Href)
 				if err != nil {
+					log.ErrorCtx(ctx, errors.WithMessage(err, "GET editions for a code-list"), log.Data{
+						"codeListID":   v.Links.Self.ID,
+						"editionsHref": v.Links.Editions.Href,
+					})
 					return
 				}
 


### PR DESCRIPTION
### What

In an attempt to fix geography CMD develop environment add an error log line after the GET on editions for a code list.

### How to review

Check that there are no potential errors in the geography homepage handler that aren't logged.

### Who can review

Anyone but me.
