### PR TITLE
Remove travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: go
-go: stable
-script: make test


### PR DESCRIPTION
### What

Removed Travis as Concourse is used instead for Continuous integration

### Who can review

Anyone except me