### PR TITLE
Release/1.2.0

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -115,6 +115,7 @@ func HomepageRender(rend RenderClient, cli CodeListClient) http.HandlerFunc {
 		})
 
 		page.Data.Items = types
+		page.BetaBannerEnabled = true
 		page.Metadata.Title = "Geography"
 		page.Breadcrumb = []model.TaxonomyNode{
 			model.TaxonomyNode{
@@ -194,7 +195,7 @@ func ListPageRender(rend RenderClient, cli CodeListClient) http.HandlerFunc {
 				page.Data.Items = pageCodes
 			}
 		}
-
+		page.BetaBannerEnabled = true
 		page.Breadcrumb = []model.TaxonomyNode{
 			model.TaxonomyNode{
 				Title: "Home",
@@ -319,6 +320,7 @@ func AreaPageRender(rend RenderClient, cli CodeListClient, dcli DatasetClient) h
 		}
 
 		page.Data.Attributes.Code = codeID
+		page.BetaBannerEnabled = true
 		page.Breadcrumb = getAreaPageRenderBreadcrumb(parentName, page.Metadata.Title, codeListID, codeID)
 
 		templateJSON, err := json.Marshal(page)


### PR DESCRIPTION
### What

Have set the `BetaBannerEnabled` flag to `true` for the geography pages. This is because the APIs are still currently in beta.

This is a release branch.

### How to review

Ensure `dp-frontend-router` is running with `GEOGRAPHY_ENABLED=true` set
Navigate to /geography routes on the ONS site
See if beta banner is displayed across these pages

### Who can review

Anyone
