### PR TITLE
Update to latest api clients library, which uses latest healthcheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/ONSdigital/dp-frontend-geography-controller
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.2.0
+	github.com/ONSdigital/dp-api-clients-go v1.2.1-0.20200221091333-445de1cff876
 	github.com/ONSdigital/dp-frontend-models v1.1.0
-	github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e
+	github.com/ONSdigital/dp-healthcheck v0.0.0-20200219161048-205cb782aff1
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/gorilla/mux v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
-github.com/ONSdigital/dp-api-clients-go v1.2.0 h1:UzceNlq6t+5yzMcJwWtCknnQPyzDkvqdcz9OJOKS9I4=
-github.com/ONSdigital/dp-api-clients-go v1.2.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
+github.com/ONSdigital/dp-api-clients-go v1.2.1-0.20200221091333-445de1cff876 h1:atrQeApQEydVWDIa5C18ERgeTJXQgXap+1C+SefS0SY=
+github.com/ONSdigital/dp-api-clients-go v1.2.1-0.20200221091333-445de1cff876/go.mod h1:GLO0g/yfePwiNX/vncyNiP4Q6hsNtwRK4z4zeEL3p18=
 github.com/ONSdigital/dp-frontend-models v1.1.0 h1:dpVTBIqyJqk4q0DJlj9xEv56HDxebC/cHQPbO5OduLw=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
-github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e h1:H2KVzsFp5oTbqjPXDlTHOB/LvYy2I6Mc8eSTLrmZkXs=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
-github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
+github.com/ONSdigital/dp-healthcheck v0.0.0-20200219161048-205cb782aff1 h1:CqtCMHec03AfCsTLEkk34q7RQJFYRRMZHq6HVVM6ZOA=
+github.com/ONSdigital/dp-healthcheck v0.0.0-20200219161048-205cb782aff1/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8 h1:MWIHCr/ud5ur9elhfvKtSjMJInqf3iUY8F4J27qGQPA=
@@ -17,7 +17,6 @@ github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8F
 github.com/ONSdigital/log.go v1.0.0 h1:hZQTuitFv4nSrpzMhpGvafUC5/8xMVnLI0CWe1rAJNc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
-github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9 h1:wWke/RUCl7VRjQhwPlR/v0glZXNYzBHdNUzf/Am2Nmg=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=


### PR DESCRIPTION
### What

- Use latest dp-api-clients-go, which use the latest dp-healthcheck.

### How to review

- Unit tests should pass
- You can try the /health endpoint locally (it should return status code 200 if the global status is OK, 429 if the global status is WARNING, or 500 if the global status is CRITICAL)

### Who can review

Anyone.