### PR TITLE
Extract version from api router url, and trimmed version prefix from link url

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/ONSdigital/dp-api-clients-go/headers"
@@ -230,7 +231,7 @@ func ListPageRender(rend RenderClient, cli CodeListClient) http.HandlerFunc {
 
 //AreaPageRender gets data about a specific code, get what datasets are associated with the code and get information
 // about those datasets, maps it and passes it to the renderer
-func AreaPageRender(rend RenderClient, cli CodeListClient, dcli DatasetClient) http.HandlerFunc {
+func AreaPageRender(rend RenderClient, cli CodeListClient, dcli DatasetClient, apiRouterVersion string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		vars := mux.Vars(req)
@@ -299,11 +300,12 @@ func AreaPageRender(rend RenderClient, cli CodeListClient, dcli DatasetClient) h
 						}
 						mutex.Lock()
 						defer mutex.Unlock()
+						datasetWebsitePath := strings.TrimPrefix(datasetWebsiteURL.Path, apiRouterVersion)
 						datasets = append(datasets, area.Dataset{
 							ID:          datasetResp.Editions[0].Links.Self.ID,
 							Label:       datasetDetails.Title,
 							Description: datasetDetails.Description,
-							URI:         datasetWebsiteURL.Path,
+							URI:         datasetWebsitePath,
 						})
 
 						return

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -435,7 +435,7 @@ func TestAreaPageRender(t *testing.T) {
 				},
 			}
 
-			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient))
+			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient, ""))
 			router.ServeHTTP(w, req)
 
 			renderCall := mockRenderClient.DoCalls()[0]
@@ -493,7 +493,7 @@ func TestAreaPageRender(t *testing.T) {
 											DatasetDimenion: codelist.Link{},
 											LatestVersion: codelist.Link{
 												ID:   "1",
-												Href: "http://localhost:22000/datasets/mid-year-pop-est/editions/time-series/versions/1",
+												Href: "http://localhost:22000/v1/datasets/mid-year-pop-est/editions/time-series/versions/1",
 											},
 										},
 									},
@@ -513,7 +513,7 @@ func TestAreaPageRender(t *testing.T) {
 				},
 			}
 
-			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient))
+			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient, "/v1"))
 			router.ServeHTTP(w, req)
 			renderCall := mockRenderClient.DoCalls()[0]
 
@@ -591,7 +591,7 @@ func TestAreaPageRender(t *testing.T) {
 				},
 			}
 
-			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient))
+			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient, ""))
 			router.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 500)
 			So(len(mockRenderClient.DoCalls()), ShouldEqual, 0)
@@ -644,7 +644,7 @@ func TestAreaPageRender(t *testing.T) {
 				},
 			}
 
-			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient))
+			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient, ""))
 			router.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 500)
 			So(len(mockRenderClient.DoCalls()), ShouldEqual, 0)
@@ -698,7 +698,7 @@ func TestAreaPageRender(t *testing.T) {
 				},
 			}
 
-			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient))
+			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient, ""))
 			router.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 500)
 			So(len(mockRenderClient.DoCalls()), ShouldEqual, 0)
@@ -773,7 +773,7 @@ func TestAreaPageRender(t *testing.T) {
 				},
 			}
 
-			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient))
+			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient, ""))
 			router.ServeHTTP(w, req)
 
 			So(w.Code, ShouldEqual, 500)
@@ -817,7 +817,7 @@ func TestAreaPageRender(t *testing.T) {
 				},
 			}
 
-			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient))
+			router.Path("/geography/{codeListID}/{codeID}").HandlerFunc(AreaPageRender(mockRenderClient, mockCodeListClient, mockDatasetClient, ""))
 			router.ServeHTTP(w, req)
 			So(w.Code, ShouldEqual, 500)
 			So(len(mockRenderClient.DoCalls()), ShouldEqual, 1)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -264,6 +265,31 @@ func TestClose(t *testing.T) {
 			So(len(hcMock.StopCalls()), ShouldEqual, 1)
 			So(len(timeoutServerMock.ShutdownCalls()), ShouldEqual, 1)
 		})
+	})
+}
+
+func TestGetAPIRouterVersion(t *testing.T) {
+
+	Convey("The api router version is correctly extracted from a valid API Router URL", t, func() {
+		version, err := service.GetAPIRouterVersion("http://localhost:23200/v1")
+		So(err, ShouldBeNil)
+		So(version, ShouldEqual, "/v1")
+	})
+
+	Convey("An empty string version is extracted from a valid unversioned API Router URL", t, func() {
+		version, err := service.GetAPIRouterVersion("http://localhost:23200")
+		So(err, ShouldBeNil)
+		So(version, ShouldEqual, "")
+	})
+
+	Convey("Extracting a version from an invalid API Router URL results in the parsing error being returned", t, func() {
+		version, err := service.GetAPIRouterVersion("hello%goodbye")
+		So(err, ShouldResemble, &url.Error{
+			Op:  "parse",
+			URL: "hello%goodbye",
+			Err: url.EscapeError("%go"),
+		})
+		So(version, ShouldEqual, "")
 	})
 }
 


### PR DESCRIPTION
# What

- Extract API Router Version from API Router URL in config
- In links returned in the response, trim the version prefix if it exists.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone